### PR TITLE
fixed nullrefs for void methods

### DIFF
--- a/BlackBox/CodeGeneration/Writer/ComparisonConfigurationWriter.cs
+++ b/BlackBox/CodeGeneration/Writer/ComparisonConfigurationWriter.cs
@@ -22,9 +22,7 @@ namespace BlackBox.CodeGeneration.Writer
             if (_configurationSectionIsWritten)
                 return;
 
-            string qualifiedName = _recordingReader.IsVoidMethod() ?
-                                   _recordingReader.GetInputParameters().First().Type.AssemblyQualifiedName : 
-                                   _recordingReader.GetAssemblyQualifiedNameOfReturnValue();
+            string qualifiedName = ConstructAssemblyQualifiedNameExample();
 
             _output.AppendLine("\t\tprotected override void ConfigureComparison(string filename)");
             _output.AppendLine("\t\t{");
@@ -42,6 +40,18 @@ namespace BlackBox.CodeGeneration.Writer
             _output.AppendLine();
 
             _configurationSectionIsWritten = true;
+        }
+
+        private string ConstructAssemblyQualifiedNameExample()
+        {
+            if (!_recordingReader.IsVoidMethod())
+                return _recordingReader.GetAssemblyQualifiedNameOfReturnValue();
+
+            bool hasInputParameters = _recordingReader.GetInputParameters().Any();
+            if (hasInputParameters)
+                return _recordingReader.GetInputParameters().First().Type.AssemblyQualifiedName;
+
+            return typeof(string).AssemblyQualifiedName;
         }
 
         private static string ConstructObjectPropertySelectorExample(string assemblyQualifiedName)

--- a/BlackBox/RecordingXmlWriter.cs
+++ b/BlackBox/RecordingXmlWriter.cs
@@ -63,11 +63,23 @@ namespace BlackBox
                                            new XElement("Parameters",
                                                from parameter in dependency.Method.GetParameters()
                                                select new XElement("FullyQualifiedType", parameter.ParameterType.AssemblyQualifiedName)),
-                                           new XElement("ReturnValues",
+                                               new XElement("ReturnValues",
                                                from returnValue in dependency.ReturnValues
-                                               select new XElement("ReturnValue",
-                                                   new XElement("FullyQualifiedType", returnValue.GetType().AssemblyQualifiedName),
-                                                   new XElement("Value", new XCData(returnValue.ToXml().ToString()))))));
+                                               select new XElement("ReturnValue", CreateDependencyReturnNode(returnValue))
+                                           )));
+
+        }
+
+        private static IEnumerable<XElement> CreateDependencyReturnNode(object dependency)
+        {
+            if (dependency == null)
+            {
+                yield return new XElement("FullyQualifiedType", "void");
+                yield return new XElement("Value", ValueNode(null));
+                yield break;
+            }
+            yield return new XElement("FullyQualifiedType", new XCData(dependency.GetType().AssemblyQualifiedName));
+            yield return new XElement("Value", new XCData(dependency.ToXml().ToString()));
         }
     }
 }


### PR DESCRIPTION
Fixed nullref for dependency method which returns void, and nullref for configuration writer which returns void and does not have any parameters
